### PR TITLE
Fix Dajax object visibility issue

### DIFF
--- a/dajax/static/dajax/jquery.dajax.core.js
+++ b/dajax/static/dajax/jquery.dajax.core.js
@@ -1,7 +1,9 @@
-var Dajax = {
-    process: function(data)
+var Dajax = window.Dajax || (function($) {
+    var that = {};
+
+    that.process = function(data)
     {
-        $.each(data, function(i,elem){
+        $.each(data, function(i,elem) {
         switch(elem.cmd)
         {
             case 'alert':
@@ -17,32 +19,32 @@ var Dajax = {
                     $(elem.id).html(elem.val);
                 }
                 else{
-                    jQuery.each($(elem.id),function(){ this[elem.prop] = elem.val; });
+                    $.each($(elem.id),function(){ this[elem.prop] = elem.val; });
                 }
             break;
 
             case 'addcc':
-                jQuery.each(elem.val,function(){
+                $.each(elem.val,function(){
                     $(elem.id).addClass(String(this));
                 });
             break;
 
             case 'remcc':
-                jQuery.each(elem.val,function(){
+                $.each(elem.val,function(){
                     $(elem.id).removeClass(String(this));
                 });
             break;
 
             case 'ap':
-                jQuery.each($(elem.id),function(){ this[elem.prop] += elem.val; });
+                $.each($(elem.id),function(){ this[elem.prop] += elem.val; });
             break;
 
             case 'pp':
-                jQuery.each($(elem.id),function(){ this[elem.prop] = elem.val + this[elem.prop]; });
+                $.each($(elem.id),function(){ this[elem.prop] = elem.val + this[elem.prop]; });
             break;
 
             case 'clr':
-                jQuery.each($(elem.id),function(){ this[elem.prop] = ""; });
+                $.each($(elem.id),function(){ this[elem.prop] = ""; });
             break;
 
             case 'red':
@@ -62,4 +64,8 @@ var Dajax = {
             }
         });
     }
-};
+
+    return that;
+}(jQuery));
+
+window.Dajax = Dajax;


### PR DESCRIPTION
## Problem Description

Currently `Dajax` object is not attach to the `window` object. This means it won't be visible to other code (`ReferenceError: Dajax is not defined`) if you use a minification process which wraps all of the minified files inside a closure (`function(){}())`).

Most of the minification libraries, including commonly used `django-pipeline` do that.
# Proposed solution

In my proposed solution, I've wrap `Dajax` object into a closure and attach it to the `window` object. I've also did some cleanup and changed the code to consistently use `$` everywhere instead of using `jQuery` in some and `$` in other places.

Attaching an object to `window` object is a fairly common thing to do if the code, like this one, is not built as a jQuery plugin.
