### PR TITLE
don't use eval in this way

### DIFF
--- a/dajax/static/dajax/dojo.dajax.core.js
+++ b/dajax/static/dajax/dojo.dajax.core.js
@@ -9,7 +9,7 @@ var Dajax = {
             break;
 
             case 'data':
-                eval( elem.fun+"(elem.val);" );
+                window[elem.fun](elem.val);
             break;
 
             case 'as':

--- a/dajax/static/dajax/jquery.dajax.core.js
+++ b/dajax/static/dajax/jquery.dajax.core.js
@@ -9,7 +9,7 @@ var Dajax = {
             break;
 
             case 'data':
-                eval( elem.fun+"(elem.val);" );
+                window[elem.fun](elem.val);
             break;
 
             case 'as':

--- a/dajax/static/dajax/mootools.dajax.core.js
+++ b/dajax/static/dajax/mootools.dajax.core.js
@@ -9,7 +9,7 @@ var Dajax = {
             break;
 
             case 'data':
-                eval( elem.fun+"(elem.val);" );
+                window[elem.fun](elem.val);
             break;
 
             case 'as':

--- a/dajax/static/dajax/prototype.dajax.core.js
+++ b/dajax/static/dajax/prototype.dajax.core.js
@@ -9,7 +9,7 @@ var Dajax = {
             break;
 
             case 'data':
-                eval( elem.fun+"(elem.val);" );
+                window[elem.fun](elem.val);
             break;
 
             case 'as':


### PR DESCRIPTION
It calls eval on a string containing a variable name; when the minification happens and the variable is renamed, the result is a runtime error.
