### PR TITLE
Django 1.7 support

### DIFF
--- a/dajax/core.py
+++ b/dajax/core.py
@@ -1,4 +1,4 @@
-from django.utils import simplejson as json
+import json
 
 
 class Dajax(object):


### PR DESCRIPTION
This little change uses python json instead of django simplejson, that is no longer available in django1.7
