### PR TITLE
Fixed depricated json dependency

### DIFF
--- a/dajax/core.py
+++ b/dajax/core.py
@@ -1,4 +1,7 @@
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json
 
 
 class Dajax(object):


### PR DESCRIPTION
Simplejson is depricated. Use json instead when available.
