### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,7 @@ How does it work?
 Example
 -------
 
-Once you've `installed dajaxice <http://django-dajaxice.readthedocs.org/en/latest/installation.html>`_ and `dajax <http://django-dajax.readthedocs.org/en/latest/installation.html>`_ you can create ajax functions in your Python code::
+Once you've `installed dajaxice <https://django-dajaxice.readthedocs.io/en/latest/installation.html>`_ and `dajax <https://django-dajax.readthedocs.io/en/latest/installation.html>`_ you can create ajax functions in your Python code::
 
 
     from dajax.core import Dajax

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-In order to use ``dajax`` you should install ``django-dajaxice`` before. Please follow these instructions `here <http://django-dajaxice.readthedocs.org/en/latest/installation.html>`_.
+In order to use ``dajax`` you should install ``django-dajaxice`` before. Please follow these instructions `here <https://django-dajaxice.readthedocs.io/en/latest/installation.html>`_.
 
 Installing Dajax
 ----------------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
